### PR TITLE
fix: declare loop variable in getOpenRoomList

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -102,7 +102,7 @@ var availableRooms = {};
 
 var getOpenRoomList = function() {
   var res = [];
-  for (key in availableRooms) {
+  for (var key in availableRooms) {
     res.push({'name': key, 'owner': availableRooms[key].owner});
   }
   return res;


### PR DESCRIPTION
## Summary
- prevent global variable leak when listing available rooms

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a6413b4d948332bda5f69df3c242a4