### PR TITLE
Add special block support and touch controls

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -241,7 +241,7 @@ io.of('/game')
 
       socket.on('line', function(nbLine) {
         //doesn't work
-        //io.of('/game').in(roomN).except(socket).emit('addLines', nbLine); 
+        //io.of('/game').in(roomN).except(socket).emit('addLines', nbLine);
        /* for (var id in io.of('/game').clients(roomN)) {
           var loopSockId = io.of('/game').clients(roomN)[id].id
           if(socket.id !== loopSockId) {
@@ -254,7 +254,25 @@ io.of('/game')
         } else {
           sendToAllButYou('addLines', nbLine, '/game', roomN, socket.id);  
         }
-        
+
+      });
+
+      socket.on('special', function(payload) {
+        var target = payload && payload.target;
+        var type = payload && payload.type;
+        if (!target || !type) {
+          return;
+        }
+
+        for (var id in io.of('/game').clients(roomN)) {
+          var targetSocket = io.of('/game').clients(roomN)[id];
+          if (targetSocket.nickname === target) {
+            io.of('/game').in(roomN).socket(targetSocket.id).emit('special', {
+              type: type,
+              from: nickname
+            });
+          }
+        }
       });
 
       var sendToAllButYou = function(msgType, msgContent, of, room, socketId) {

--- a/src/public/partials/game.html
+++ b/src/public/partials/game.html
@@ -16,45 +16,63 @@
 			<a ng-click="launchGame()" class="btn btn-large">Launch the game</a>
 		</div>
 
-		<div class="hidden-on-desktop">
-			<div ng-show="gameState == 'on'">
-				<div class="btn" ng-click="sendGameEvent(3)">
-					<i class="icon-arrow-left icon-2x"></i>
-				</div>
+                <div class="hidden-on-desktop">
+                        <div ng-show="gameState == 'on'">
+                                <div class="btn" ng-click="sendGameEvent(3)">
+                                        <i class="icon-arrow-left icon-2x"></i>
+                                </div>
 				<div class="btn" ng-click="sendGameEvent(5)">
 					<i class="icon-arrow-down icon-2x"></i>
 				</div>
-				<div class="btn" ng-click="sendGameEvent(4)">
-					<i class="icon-arrow-right icon-2x"></i>
-				</div>
-				<div class="btn pull-right" ng-click="sendGameEvent(1)">
-					<i class="icon-repeat icon-2x"></i>
-				</div>
-			</div>
-		</div>
+                                <div class="btn" ng-click="sendGameEvent(4)">
+                                        <i class="icon-arrow-right icon-2x"></i>
+                                </div>
+                                <div class="btn" ng-click="sendGameEvent(5)">
+                                        <i class="icon-hand-down icon-2x"></i>
+                                </div>
+                                <div class="btn pull-right" ng-click="sendGameEvent(1)">
+                                        <i class="icon-repeat icon-2x"></i>
+                                </div>
+                        </div>
+                </div>
 	</div>
 
-	<div class="span5 hidden-on-phone">	
-		<div  ng-include="'partials/chat.html'"></div>
+        <div class="span5 hidden-on-phone">
+                <div  ng-include="'partials/chat.html'"></div>
 
-		
 
-	</div>
-	<div class="span4 hidden-on-phone">
-		<h2>GameZone</h2>
-		<div ng-repeat="(nickname, opt) in gameFields" class="span2">
 
-			<table class="game-zone"  ng-class="{gray: opt.status =='gameover'}">
-				<tr ng-repeat="line in opt.zone">
-					<td ng-repeat="cell in line" ng-class="getClassFor(cell.val)" class="game-mini-cell">
+        </div>
+        <div class="span4">
+                <h2>GameZone</h2>
+                <div ng-repeat="(nickname, opt) in gameFields" class="span2">
 
-					</td>
-				</tr>
-			</table>
-			{{nickname}} / {{opt.status}}
-		</div>
-	</div>
-	
+                        <table class="game-zone"  ng-class="{gray: opt.status =='gameover'}">
+                                <tr ng-repeat="line in opt.zone">
+                                        <td ng-repeat="cell in line" ng-class="getClassFor(cell.val)" class="game-mini-cell">
 
-	
+                                        </td>
+                                </tr>
+                        </table>
+                        {{nickname}} / {{opt.status}}
+                </div>
+
+                <div class="special-panel" ng-show="specialInventory.length">
+                        <h3>Special blocks</h3>
+                        <div class="alert" ng-show="specialMessage">{{specialMessage}}</div>
+                        <label>Target</label>
+                        <select ng-model="selectedTarget" ng-options="opponent for opponent in getOpponentList()">
+                                <option value="">Choose opponent</option>
+                        </select>
+                        <div class="special-grid">
+                                <button class="btn btn-small" ng-repeat="special in specialInventory"
+                                        ng-click="useSpecial(special, selectedTarget)" ng-disabled="!selectedTarget">
+                                        {{getSpecialLabel(special)}}
+                                </button>
+                        </div>
+                </div>
+        </div>
+
+
+
 </div>

--- a/src/public/stylesheets/tetrinet.less
+++ b/src/public/stylesheets/tetrinet.less
@@ -53,8 +53,20 @@
 }
 
 .pulsate {
-	-webkit-animation: pulsate 1s ease-out;
-	-webkit-animation-iteration-count: infinite;
+        -webkit-animation: pulsate 1s ease-out;
+        -webkit-animation-iteration-count: infinite;
+}
+
+.special-panel {
+        margin-top: 10px;
+        padding: 10px;
+        background: #f7f7f7;
+        border: 1px solid #ddd;
+        border-radius: 4px;
+}
+
+.special-grid .btn {
+        margin: 4px 4px 0 0;
 }
 
 @-webkit-keyframes pulsate {


### PR DESCRIPTION
## Summary
- add special block inventory, usage, and targeting between opponents
- send special events through the game server and apply effects to targeted boards
- improve mobile controls and surface special block UI with refreshed styling

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69271b6d11348332947953529f6d89a2)